### PR TITLE
Fix floating shop item physics

### DIFF
--- a/src/main/java/com/gravityyfh/entreprisemanager/Shop/ShopManager.java
+++ b/src/main/java/com/gravityyfh/entreprisemanager/Shop/ShopManager.java
@@ -401,9 +401,11 @@ public class ShopManager {
             Item item = itemLocation.getWorld().dropItem(itemLocation, displayStack);
             item.setPickupDelay(Integer.MAX_VALUE);
             item.setInvulnerable(true);
+            item.setGravity(false);
+            item.setVelocity(item.getVelocity().zero());
             item.setTicksLived(1);
             shop.setDisplayItemID(item.getUniqueId());
-         });
+        });
       }
    }
 


### PR DESCRIPTION
## Summary
- stop shop display item from falling due to gravity

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684766b0376c8321afe8718d105f595f