### PR TITLE
Fix shop deletion cleanup

### DIFF
--- a/src/main/java/com/gravityyfh/entreprisemanager/Shop/ShopManager.java
+++ b/src/main/java/com/gravityyfh/entreprisemanager/Shop/ShopManager.java
@@ -349,7 +349,7 @@ public class ShopManager {
          if (signBlock != null) {
             signBlock.getChunk().load();
             Bukkit.getScheduler().runTask(this.plugin, () -> {
-               signBlock.breakNaturally();
+               signBlock.setType(Material.AIR, false);
             });
          }
 
@@ -405,6 +405,7 @@ public class ShopManager {
             item.setVelocity(item.getVelocity().zero());
             item.setTicksLived(1);
             shop.setDisplayItemID(item.getUniqueId());
+            this.saveShops();
         });
       }
    }


### PR DESCRIPTION
## Summary
- fully remove shop sign instead of breaking it
- persist floating item ID upon creation so it's deleted when removing shop

## Testing
- `javac -version`

------
https://chatgpt.com/codex/tasks/task_e_684769b544688321aac20d7089ca88ea