### PR TITLE
Implement auto-removal of shops when plot type changes

### DIFF
--- a/src/main/java/com/gravityyfh/entreprisemanager/Shop/ShopDestructionListener.java
+++ b/src/main/java/com/gravityyfh/entreprisemanager/Shop/ShopDestructionListener.java
@@ -2,10 +2,12 @@ package com.gravityyfh.entreprisemanager.Shop;
 
 import com.gravityyfh.entreprisemanager.EntrepriseManager;
 import com.palmergames.bukkit.towny.event.PlotClearEvent;
+import com.palmergames.bukkit.towny.event.plot.PlayerChangePlotTypeEvent;
 import com.palmergames.bukkit.towny.event.plot.changeowner.PlotChangeOwnerEvent;
 import com.palmergames.bukkit.towny.event.town.TownRuinedEvent;
 import com.palmergames.bukkit.towny.event.town.TownUnclaimEvent;
 import com.palmergames.bukkit.towny.object.TownBlock;
+import com.palmergames.bukkit.towny.object.TownBlockType;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
@@ -117,5 +119,16 @@ public class ShopDestructionListener implements Listener {
          this.handlePlotShopsDeletion(townBlock, "Ville en Ruine");
       }
 
+   }
+
+   @EventHandler(
+      priority = EventPriority.MONITOR,
+      ignoreCancelled = true
+   )
+   public void onPlotTypeChange(PlayerChangePlotTypeEvent event) {
+      TownBlock townBlock = event.getTownBlock();
+      if (townBlock != null && event.getNewType() != TownBlockType.COMMERCIAL) {
+         this.handlePlotShopsDeletion(townBlock, "Changement de type de parcelle");
+      }
    }
 }

--- a/src/main/java/com/gravityyfh/entreprisemanager/Shop/ShopManager.java
+++ b/src/main/java/com/gravityyfh/entreprisemanager/Shop/ShopManager.java
@@ -5,6 +5,7 @@ import com.gravityyfh.entreprisemanager.EntrepriseManagerLogic;
 import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.TownBlock;
+import com.palmergames.bukkit.towny.object.TownBlockType;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -131,6 +132,11 @@ public class ShopManager {
                      Resident resident = TownyAPI.getInstance().getResident(player);
                      if (townBlock == null || !townBlock.hasResident() || !townBlock.getResident().equals(resident)) {
                         player.sendMessage(ChatColor.RED + "Vous devez être sur une parcelle Towny qui vous appartient.");
+                        return;
+                     }
+
+                     if (townBlock.getType() != TownBlockType.COMMERCIAL) {
+                        player.sendMessage(ChatColor.RED + "La parcelle doit être de type SHOP pour placer une boutique.");
                         return;
                      }
                   } catch (Exception var8) {


### PR DESCRIPTION
## Summary
- require Towny commercial plot type to create a shop
- remove shops on plot-type change to anything other than commercial

## Testing
- `mvn -q -DskipTests package` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_684772433d6883218a3c0a6cfc4c0f5d