### PR TITLE
Fix floating shop items despawning

### DIFF
--- a/src/main/java/com/gravityyfh/entreprisemanager/Shop/ShopManager.java
+++ b/src/main/java/com/gravityyfh/entreprisemanager/Shop/ShopManager.java
@@ -407,6 +407,7 @@ public class ShopManager {
             Item item = itemLocation.getWorld().dropItem(itemLocation, displayStack);
             item.setPickupDelay(Integer.MAX_VALUE);
             item.setInvulnerable(true);
+            item.setUnlimitedLifetime(true);
             item.setGravity(false);
             item.setVelocity(item.getVelocity().zero());
             item.setTicksLived(1);


### PR DESCRIPTION
## Summary
- keep spawned shop display items from disappearing after 5 minutes by calling `Item#setUnlimitedLifetime`

## Testing
- `mvn -q test` *(fails: Could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6847748b5a80832182cf2160f303e013