### PR TITLE
Improve Towny shop cleanup

### DIFF
--- a/src/main/java/com/gravityyfh/entreprisemanager/Shop/ShopDestructionListener.java
+++ b/src/main/java/com/gravityyfh/entreprisemanager/Shop/ShopDestructionListener.java
@@ -9,6 +9,7 @@ import com.palmergames.bukkit.towny.event.town.TownRuinedEvent;
 import com.palmergames.bukkit.towny.event.town.TownUnclaimEvent;
 import com.palmergames.bukkit.towny.object.TownBlock;
 import com.palmergames.bukkit.towny.object.TownBlockType;
+import com.palmergames.bukkit.towny.object.WorldCoord;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
@@ -65,11 +66,11 @@ public class ShopDestructionListener implements Listener {
       }
    }
 
-   private void handlePlotShopsDeletion(TownBlock townBlock, String reason) {
-      if (townBlock != null) {
-         List<Shop> shopsOnPlot = this.shopManager.getShopsByPlot(townBlock);
+   private void handlePlotShopsDeletion(WorldCoord worldCoord, String reason) {
+      if (worldCoord != null) {
+         List<Shop> shopsOnPlot = this.shopManager.getShopsByPlot(worldCoord);
          if (!shopsOnPlot.isEmpty()) {
-            this.plugin.getLogger().log(Level.INFO, "La parcelle " + townBlock.getWorldCoord().toString() + " a subi l'événement '" + reason + "'. Suppression de " + shopsOnPlot.size() + " boutique(s).");
+            this.plugin.getLogger().log(Level.INFO, "La parcelle " + worldCoord.toString() + " a subi l'événement '" + reason + "'. Suppression de " + shopsOnPlot.size() + " boutique(s).");
             ShopManager var10001 = this.shopManager;
             Objects.requireNonNull(var10001);
             shopsOnPlot.forEach(var10001::deleteShop);
@@ -83,7 +84,7 @@ public class ShopDestructionListener implements Listener {
       ignoreCancelled = true
    )
    public void onPlotChangeOwner(PlotChangeOwnerEvent event) {
-      this.handlePlotShopsDeletion(event.getTownBlock(), "Changement de Propriétaire");
+      this.handlePlotShopsDeletion(event.getTownBlock().getWorldCoord(), "Changement de Propriétaire");
    }
 
    @EventHandler(
@@ -92,7 +93,7 @@ public class ShopDestructionListener implements Listener {
    )
    public void onTownUnclaim(TownUnclaimEvent event) {
       try {
-         this.handlePlotShopsDeletion(event.getWorldCoord().getTownBlock(), "Unclaim");
+         this.handlePlotShopsDeletion(event.getWorldCoord(), "Unclaim");
       } catch (Exception var3) {
          this.plugin.getLogger().log(Level.WARNING, "Impossible de gérer TownUnclaimEvent pour " + event.getWorldCoord().toString(), var3);
       }
@@ -104,7 +105,7 @@ public class ShopDestructionListener implements Listener {
       ignoreCancelled = true
    )
    public void onPlotUnclaim(PlotUnclaimEvent event) {
-      this.handlePlotShopsDeletion(event.getTownBlock(), "Plot Unclaim");
+      this.handlePlotShopsDeletion(event.getTownBlock().getWorldCoord(), "Plot Unclaim");
    }
 
    @EventHandler(
@@ -112,7 +113,7 @@ public class ShopDestructionListener implements Listener {
       ignoreCancelled = true
    )
    public void onPlotClear(PlotClearEvent event) {
-      this.handlePlotShopsDeletion(event.getTownBlock(), "Plot Clear");
+      this.handlePlotShopsDeletion(event.getTownBlock().getWorldCoord(), "Plot Clear");
    }
 
    @EventHandler(
@@ -125,7 +126,7 @@ public class ShopDestructionListener implements Listener {
 
       while(var2.hasNext()) {
          TownBlock townBlock = (TownBlock)var2.next();
-         this.handlePlotShopsDeletion(townBlock, "Ville en Ruine");
+         this.handlePlotShopsDeletion(townBlock.getWorldCoord(), "Ville en Ruine");
       }
 
    }
@@ -137,7 +138,7 @@ public class ShopDestructionListener implements Listener {
    public void onPlotTypeChange(PlayerChangePlotTypeEvent event) {
       TownBlock townBlock = event.getTownBlock();
       if (townBlock != null && event.getNewType() != TownBlockType.COMMERCIAL) {
-         this.handlePlotShopsDeletion(townBlock, "Changement de type de parcelle");
+         this.handlePlotShopsDeletion(townBlock.getWorldCoord(), "Changement de type de parcelle");
       }
    }
 }

--- a/src/main/java/com/gravityyfh/entreprisemanager/Shop/ShopManager.java
+++ b/src/main/java/com/gravityyfh/entreprisemanager/Shop/ShopManager.java
@@ -6,6 +6,7 @@ import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.TownBlock;
 import com.palmergames.bukkit.towny.object.TownBlockType;
+import com.palmergames.bukkit.towny.object.WorldCoord;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -17,6 +18,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
@@ -300,11 +302,21 @@ public class ShopManager {
       }).sorted(Comparator.comparing(Shop::getCreationDate)).collect(Collectors.toList());
    }
 
-   public List<Shop> getShopsByPlot(TownBlock townBlock) {
-      return townBlock == null ? Collections.emptyList() : (List)this.shops.values().stream().filter((shop) -> {
-         TownBlock shopPlot = TownyAPI.getInstance().getTownBlock(shop.getLocation());
-         return townBlock.equals(shopPlot);
-      }).collect(Collectors.toList());
+   public List<Shop> getShopsByPlot(WorldCoord worldCoord) {
+      if (worldCoord == null) {
+         return Collections.emptyList();
+      } else {
+         return this.shops.values().stream().filter((shop) -> {
+            Location loc = shop.getLocation();
+            if (loc == null || loc.getWorld() == null) {
+               return false;
+            }
+
+            return Objects.equals(loc.getWorld().getName(), worldCoord.getWorldName()) &&
+               loc.getChunk().getX() == worldCoord.getX() &&
+               loc.getChunk().getZ() == worldCoord.getZ();
+         }).collect(Collectors.toList());
+      }
    }
 
    private String formatMaterialName(Material material) {


### PR DESCRIPTION
## Summary
- drop TownBlock arguments in shop deletion handlers
- use `WorldCoord` to find shops within a plot
- update destruction listeners to supply `WorldCoord`

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_6847e7b8a3a483219451c60a6e8e16df