### PR TITLE
Implement admin cleanup for floating shop items

### DIFF
--- a/src/main/java/com/gravityyfh/entreprisemanager/EntrepriseCommandHandler.java
+++ b/src/main/java/com/gravityyfh/entreprisemanager/EntrepriseCommandHandler.java
@@ -347,7 +347,7 @@ public class EntrepriseCommandHandler implements CommandExecutor {
             return;
         }
         if (args.length < 2) {
-            player.sendMessage(ChatColor.RED + "Usage: /entreprise admin <forcepay|reload|forcesave>");
+            player.sendMessage(ChatColor.RED + "Usage: /entreprise admin <forcepay|reload|forcesave|cleandisplay>");
             return;
         }
         String subCmd = args[1].toLowerCase();
@@ -355,6 +355,7 @@ public class EntrepriseCommandHandler implements CommandExecutor {
             case "forcepay": adminForcePayCommand(player); break;
             case "reload": adminReloadCommand(player); break;
             case "forcesave": adminForceSaveCommand(player); break;
+            case "cleandisplay": adminCleanDisplayCommand(player); break;
             default: player.sendMessage(ChatColor.RED + "Sous-commande admin inconnue: " + subCmd); break;
         }
     }
@@ -386,6 +387,20 @@ public class EntrepriseCommandHandler implements CommandExecutor {
         if (!player.hasPermission("entreprisemanager.admin.forcesave")) { player.sendMessage(ChatColor.RED + "Permission refusée."); return; }
         entrepriseLogic.saveEntreprises();
         player.sendMessage(ChatColor.GREEN + "Données des entreprises sauvegardées manuellement !");
+    }
+
+    private void adminCleanDisplayCommand(Player player) {
+        if (!player.hasPermission("entreprisemanager.admin.cleandisplay")) {
+            player.sendMessage(ChatColor.RED + "Permission refusée.");
+            return;
+        }
+
+        boolean removed = plugin.getShopManager().removeTargetedDisplayItem(player);
+        if (removed) {
+            player.sendMessage(ChatColor.GREEN + "Item de boutique supprimé.");
+        } else {
+            player.sendMessage(ChatColor.RED + "Aucun item de boutique trouvé à portée.");
+        }
     }
 
     private void handleStatsCommand(Player player, String[] args) {

--- a/src/main/java/com/gravityyfh/entreprisemanager/Shop/ShopManager.java
+++ b/src/main/java/com/gravityyfh/entreprisemanager/Shop/ShopManager.java
@@ -44,6 +44,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.RayTraceResult;
+import org.bukkit.util.Vector;
 
 public class ShopManager {
    private final EntrepriseManager plugin;
@@ -563,8 +564,38 @@ public class ShopManager {
                   }
 
                });
+        }
+      }
+   }
+
+   /**
+    * Supprime l'item flottant ciblé par le joueur s'il correspond 
+    * à un affichage de boutique (pickupDelay à Integer.MAX_VALUE).
+    * @param player Joueur exécutant la commande
+    * @return true si un item a été supprimé
+    */
+   public boolean removeTargetedDisplayItem(Player player) {
+      Location eye = player.getEyeLocation();
+      Vector direction = eye.getDirection().normalize();
+
+      for(double d = 0.0D; d <= 5.0D; d += 0.5D) {
+         Location check = eye.clone().add(direction.clone().multiply(d));
+         Collection<Entity> entities = check.getWorld().getNearbyEntities(check, 0.5D, 0.5D, 0.5D);
+         Iterator<Entity> iterator = entities.iterator();
+
+         while(iterator.hasNext()) {
+            Entity ent = iterator.next();
+            if (ent instanceof Item) {
+               Item item = (Item)ent;
+               if (item.getPickupDelay() == Integer.MAX_VALUE) {
+                  item.remove();
+                  return true;
+               }
             }
          }
       }
+
+      return false;
    }
+}
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -19,6 +19,9 @@ permissions:
   entreprisemanager.admin:
     description: Permet l'utilisation des fonctionnalités administratives de l'EntrepriseManager
     default: op
+  entreprisemanager.admin.cleandisplay:
+    description: Autorise la suppression manuelle d'un item de boutique bloqué
+    default: op
   entreprisemanager.declare:
     description: Permet de déclarer des entreprises
     default: true


### PR DESCRIPTION
## Summary
- add admin command `cleandisplay` to remove invulnerable floating shop items
- support removing the targeted item via `ShopManager.removeTargetedDisplayItem`
- document new permission `entreprisemanager.admin.cleandisplay`

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68484fd8d3f08321820d97e0bcc3dfa6