### PR TITLE
Fix shop removal on Towny plot unclaim

### DIFF
--- a/src/main/java/com/gravityyfh/entreprisemanager/Shop/ShopDestructionListener.java
+++ b/src/main/java/com/gravityyfh/entreprisemanager/Shop/ShopDestructionListener.java
@@ -5,6 +5,7 @@ import com.palmergames.bukkit.towny.event.PlotClearEvent;
 import com.palmergames.bukkit.towny.event.plot.PlayerChangePlotTypeEvent;
 import com.palmergames.bukkit.towny.event.plot.changeowner.PlotChangeOwnerEvent;
 import com.palmergames.bukkit.towny.event.plot.changeowner.PlotUnclaimEvent;
+import com.palmergames.bukkit.towny.event.plot.changeowner.PlotPreUnclaimEvent;
 import com.palmergames.bukkit.towny.event.town.TownRuinedEvent;
 import com.palmergames.bukkit.towny.event.town.TownUnclaimEvent;
 import com.palmergames.bukkit.towny.object.TownBlock;
@@ -106,6 +107,14 @@ public class ShopDestructionListener implements Listener {
    )
    public void onPlotUnclaim(PlotUnclaimEvent event) {
       this.handlePlotShopsDeletion(event.getTownBlock().getWorldCoord(), "Plot Unclaim");
+   }
+
+   @EventHandler(
+           priority = EventPriority.MONITOR,
+           ignoreCancelled = true
+   )
+   public void onPlotPreUnclaim(PlotPreUnclaimEvent event) {
+      this.handlePlotShopsDeletion(event.getTownBlock().getWorldCoord(), "Plot Pre-Unclaim");
    }
 
    @EventHandler(

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ version: '${project.version}'
 main: com.gravityyfh.entreprisemanager.EntrepriseManager
 api-version: 1.20
 
-softdepend: [QuickShop, CoreProtect, TreeCuter]
+softdepend: [QuickShop, CoreProtect, TreeCuter, Towny]
 
 
 commands:


### PR DESCRIPTION
## Summary
- add Towny `PlotPreUnclaimEvent` listener to remove shops earlier
- declare Towny as a soft dependency

## Testing
- `mvn test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6848730c07b48321a6b2c065f4d4b51f