### PR TITLE
Fix floating shop item flicker

### DIFF
--- a/src/main/java/com/gravityyfh/entreprisemanager/EntrepriseManager.java
+++ b/src/main/java/com/gravityyfh/entreprisemanager/EntrepriseManager.java
@@ -9,6 +9,7 @@ import com.gravityyfh.entreprisemanager.Listener.EntityDamageListener;
 import com.gravityyfh.entreprisemanager.Listener.EntityDeathListener;
 import com.gravityyfh.entreprisemanager.Listener.TreeCutListener;
 import com.gravityyfh.entreprisemanager.Shop.ShopDestructionListener;
+import com.gravityyfh.entreprisemanager.Shop.ShopDisplayItemListener;
 import com.gravityyfh.entreprisemanager.Shop.ShopGUI;
 import com.gravityyfh.entreprisemanager.Shop.ShopInteractionListener;
 import com.gravityyfh.entreprisemanager.Shop.ShopManager;
@@ -33,6 +34,7 @@ public class EntrepriseManager extends JavaPlugin implements Listener {
     private TownyListener townyListener;
     private ShopInteractionListener shopInteractionListener;
     private ShopDestructionListener shopDestructionListener;
+    private ShopDisplayItemListener shopDisplayItemListener;
     private BlockPlaceListener blockPlaceListener;
     private CraftItemListener craftItemListener;
     private EntityDamageListener entityDamageListener;
@@ -71,6 +73,8 @@ public class EntrepriseManager extends JavaPlugin implements Listener {
             this.getLogger().info("ShopInteractionListener initialisé.");
             this.shopDestructionListener = new ShopDestructionListener(this);
             this.getLogger().info("ShopDestructionListener initialisé.");
+            this.shopDisplayItemListener = new ShopDisplayItemListener();
+            this.getLogger().info("ShopDisplayItemListener initialisé.");
             this.blockPlaceListener = new BlockPlaceListener(this, this.entrepriseLogic);
             this.getLogger().info("BlockPlaceListener initialisé.");
             this.craftItemListener = new CraftItemListener(this, this.entrepriseLogic);
@@ -127,6 +131,10 @@ public class EntrepriseManager extends JavaPlugin implements Listener {
 
         if (this.shopDestructionListener != null) {
             this.getServer().getPluginManager().registerEvents(this.shopDestructionListener, this);
+        }
+
+        if (this.shopDisplayItemListener != null) {
+            this.getServer().getPluginManager().registerEvents(this.shopDisplayItemListener, this);
         }
 
         if (this.blockPlaceListener != null) {

--- a/src/main/java/com/gravityyfh/entreprisemanager/Shop/ShopDisplayItemListener.java
+++ b/src/main/java/com/gravityyfh/entreprisemanager/Shop/ShopDisplayItemListener.java
@@ -1,0 +1,23 @@
+package com.gravityyfh.entreprisemanager.Shop;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.ItemMergeEvent;
+import org.bukkit.entity.Item;
+
+/**
+ * Listener empêchant la fusion des items utilisés comme affichage de boutique.
+ */
+public class ShopDisplayItemListener implements Listener {
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onItemMerge(ItemMergeEvent event) {
+        Item entity = event.getEntity();
+        Item target = event.getTarget();
+        // Les items de vitrine ont un délai de ramassage MAX_VALUE
+        if (entity.getPickupDelay() == Integer.MAX_VALUE || target.getPickupDelay() == Integer.MAX_VALUE) {
+            event.setCancelled(true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- prevent floating shop items from merging with dropped items by cancelling ItemMergeEvent
- register new listener

## Testing
- `javac -version`
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848abf5206c8321830afbbfde21c4c2